### PR TITLE
Fix duplicate email error element

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -48,7 +48,6 @@
                 <p id="email-error" style="color: red; display: none;">⚠️ Les adresses e-mail ne correspondent pas. Veuillez réessayer.</p>
             </form>            
     
-            <p id="email-error" style="color: red; display: none;">Les adresses e-mail ne correspondent pas. Veuillez réessayer.</p>
         </section>
     </main>
 


### PR DESCRIPTION
## Summary
- remove duplicate `email-error` element in contact page

## Testing
- `tidy -errors contact.html`
- `tidy -errors index.html`
- `tidy -errors dates.html`
- `tidy -errors photos.html`
- `tidy -errors videos.html`


------
https://chatgpt.com/codex/tasks/task_e_683fe492bcfc8330a6433e0a5501591a